### PR TITLE
Add support for DAR screenshots

### DIFF
--- a/Source/DX11VideoProcessor.cpp
+++ b/Source/DX11VideoProcessor.cpp
@@ -2041,16 +2041,22 @@ HRESULT CDX11VideoProcessor::SetWindowRect(const CRect& windowRect)
 	return hr;
 }
 
-HRESULT CDX11VideoProcessor::GetCurentImage(long *pDIBImage)
+HRESULT CDX11VideoProcessor::GetCurrentImage(long *pDIBImage, CRect targetRect)
 {
-	CRect srcRect(m_srcRect);
+	CRect srcRect(m_srcRect), useRect;
 	int w, h;
-	if (m_iRotation == 90 || m_iRotation == 270) {
-		w = srcRect.Height();
-		h = srcRect.Width();
+	if (!targetRect.IsRectEmpty()) {
+		useRect = targetRect;
 	} else {
-		w = srcRect.Width();
-		h = srcRect.Height();
+		useRect = srcRect;
+	}
+
+	if (m_iRotation == 90 || m_iRotation == 270) {
+		w = useRect.Height();
+		h = useRect.Width();
+	} else {
+		w = useRect.Width();
+		h = useRect.Height();
 	}
 	CRect imageRect(0, 0, w, h);
 

--- a/Source/DX11VideoProcessor.h
+++ b/Source/DX11VideoProcessor.h
@@ -166,7 +166,7 @@ public:
 	void SetVideoRect(const CRect& videoRect);
 	HRESULT SetWindowRect(const CRect& windowRect);
 
-	HRESULT GetCurentImage(long *pDIBImage);
+	HRESULT GetCurrentImage(long* pDIBImage, CRect targetRect = { 0 });
 	HRESULT GetDisplayedImage(BYTE **ppDib, unsigned* pSize);
 	HRESULT GetVPInfo(CStringW& str);
 

--- a/Source/DX9VideoProcessor.cpp
+++ b/Source/DX9VideoProcessor.cpp
@@ -1186,16 +1186,22 @@ HRESULT CDX9VideoProcessor::SetWindowRect(const CRect& windowRect)
 	return S_OK;
 }
 
-HRESULT CDX9VideoProcessor::GetCurentImage(long *pDIBImage)
+HRESULT CDX9VideoProcessor::GetCurrentImage(long* pDIBImage, CRect targetRect) 
 {
-	CRect srcRect(m_srcRect);
+	CRect srcRect(m_srcRect), useRect;
 	int w, h;
-	if (m_iRotation == 90 || m_iRotation == 270) {
-		w = srcRect.Height();
-		h = srcRect.Width();
+	if (!targetRect.IsRectEmpty()) {
+		useRect = targetRect;
 	} else {
-		w = srcRect.Width();
-		h = srcRect.Height();
+		useRect = srcRect;
+	}
+
+	if (m_iRotation == 90 || m_iRotation == 270) {
+		w = useRect.Height();
+		h = useRect.Width();
+	} else {
+		w = useRect.Width();
+		h = useRect.Height();
 	}
 	CRect imageRect(0, 0, w, h);
 

--- a/Source/DX9VideoProcessor.h
+++ b/Source/DX9VideoProcessor.h
@@ -133,7 +133,7 @@ public:
 	HRESULT SetWindowRect(const CRect& windowRect);
 
 	IDirect3DDeviceManager9* GetDeviceManager9() { return m_pD3DDeviceManager; }
-	HRESULT GetCurentImage(long *pDIBImage);
+	HRESULT GetCurrentImage(long* pDIBImage, CRect targetRect = { 0 });
 	HRESULT GetDisplayedImage(BYTE **ppDib, unsigned *pSize);
 	HRESULT GetVPInfo(CStringW& str);
 


### PR DESCRIPTION
I added a feature that can be used from mpc-hc to pull screenshots via GetBin.  Ideally this code would make its way to GetCurrentImage, but if not, it can live in GetBin without affecting any other programs using it.

I will submit a patch to mpc-hc to take advantage of this (which will silently revert to the old behavior if this feature is not implemented).