### PR TITLE
Support flipping output

### DIFF
--- a/Source/DX11VideoProcessor.h
+++ b/Source/DX11VideoProcessor.h
@@ -182,6 +182,7 @@ public:
 	void SetSwapEffect(int value) { m_iSwapEffect = value; }
 
 	void SetRotation(int value);
+	void SetFlip(bool value);
 
 	void Flush();
 

--- a/Source/DX9VideoProcessor.cpp
+++ b/Source/DX9VideoProcessor.cpp
@@ -1437,6 +1437,13 @@ void CDX9VideoProcessor::SetRotation(int value)
 	UpdateTexures(m_videoRect.Size());
 }
 
+void CDX9VideoProcessor::SetFlip(bool value)
+{
+	m_bFlip = value;
+	UpdateTexures(m_videoRect.Size());
+}
+
+
 void CDX9VideoProcessor::Flush()
 {
 	if (m_DXVA2VP.IsReady()) {
@@ -1738,6 +1745,9 @@ HRESULT CDX9VideoProcessor::ResizeShaderPass(IDirect3DTexture9* pTexture, IDirec
 			// one pass resize for height
 			hr = TextureResizeShader(pTexture, srcRect, dstRect, resizerY, m_iRotation);
 		}
+		else if (m_bFlip) {
+			hr = TextureResizeShader(pTexture, srcRect, dstRect, m_pShaderUpscaleX.p, m_iRotation);
+		}
 		else {
 			// no resize
 			hr = m_pD3DDevEx->SetRenderTarget(0, pRenderTarget);
@@ -2036,6 +2046,11 @@ HRESULT CDX9VideoProcessor::TextureResizeShader(IDirect3DTexture9* pTexture, con
 		points[2] = { dstRect.left,  dstRect.bottom };
 		points[3] = { dstRect.right, dstRect.bottom };
 		break;
+	}
+
+	if (m_bFlip && iRotation == m_iRotation) { //if iRotation is different (= 0), we have already transformed once and are doing a simple scale
+		std::swap(points[0], points[1]);
+		std::swap(points[2], points[3]);
 	}
 
 	MYD3DVERTEX<1> v[] = {

--- a/Source/DX9VideoProcessor.h
+++ b/Source/DX9VideoProcessor.h
@@ -148,6 +148,7 @@ public:
 	void SetSwapEffect(int value) { m_iSwapEffect = value; }
 
 	void SetRotation(int value);
+	void SetFlip(bool value);
 
 	void Flush();
 

--- a/Source/VideoProcessor.h
+++ b/Source/VideoProcessor.h
@@ -68,6 +68,7 @@ protected:
 	CRect m_renderRect;
 
 	int m_iRotation = 0;
+	bool m_bFlip = false;
 	bool m_bFinalPass = false;
 
 	DXVA2_ValueRange m_DXVA2ProcAmpRanges[4] = {};
@@ -132,6 +133,7 @@ public:
 	void SetDeintDouble(bool value) { m_bDeintDouble = value; }
 	void SetShowStats(bool value)   { m_bShowStats   = value; }
 	void SetInterpolateAt50pct(bool value) { m_bInterpolateAt50pct = value; }
+	bool GetFlip() { return m_bFlip; };
 
 	bool CheckGraphPlacement();
 	void CalcGraphParams();

--- a/Source/VideoRenderer.cpp
+++ b/Source/VideoRenderer.cpp
@@ -1162,6 +1162,15 @@ STDMETHODIMP CMpcVideoRenderer::GetBool(LPCSTR field, bool* value)
 		return S_OK;
 	}
 
+	if (!strcmp(field, "flip")) {
+		if (m_bUsedD3D11) {
+			*value = m_DX11_VP.GetFlip();
+		} else {
+			*value = m_DX9_VP.GetFlip();
+		}
+		return S_OK;
+	}
+
 	return E_INVALIDARG;
 }
 
@@ -1273,6 +1282,17 @@ STDMETHODIMP CMpcVideoRenderer::SetBool(LPCSTR field, bool value)
 
 	if (!strcmp(field, "lessRedraws")) {
 		m_bForceRedrawing = !value;
+		return S_OK;
+	}
+
+	if (!strcmp(field, "flip")) {
+		CAutoLock cRendererLock(&m_RendererLock);
+		if (m_bUsedD3D11) {
+			m_DX11_VP.SetFlip(value);
+		} else {
+			m_DX9_VP.SetFlip(value);
+		}
+
 		return S_OK;
 	}
 


### PR DESCRIPTION
Allows a flipped (mirror image) video frame.

Necessary for mpc-hc to support flipping and mirror image, which are supported with the internal renderers.