### PR TITLE
Add Support for RTX Video HDR

### DIFF
--- a/Source/D3D11VP.h
+++ b/Source/D3D11VP.h
@@ -182,8 +182,15 @@ private:
 
 	HRESULT SetSuperResNvidia(const bool enable);
 	HRESULT SetSuperResIntel(const bool enable);
+
+	//tests if there is HDR support for RTX Video HDR
+	HRESULT ToggleNvidiaVpTrueHDR(bool enable);
+	bool NvidiaDriverSupportsTrueHDR();
+
 public:
 	HRESULT SetSuperRes(const int iSuperRes);
+	HRESULT SetRTXVideoHDR(bool enable);
+	bool GpuDriverSupportsVpAutoHDR();
 
 	HRESULT Process(ID3D11Texture2D* pRenderTarget, const D3D11_VIDEO_FRAME_FORMAT sampleFormat, const bool second);
 };

--- a/Source/DX11VideoProcessor.cpp
+++ b/Source/DX11VideoProcessor.cpp
@@ -1800,8 +1800,9 @@ HRESULT CDX11VideoProcessor::InitializeD3D11VP(const FmtConvParams_t& params, co
 		m_bRTXVideoHDR_supported = (m_D3D11VP.SetRTXVideoHDR(true) == S_OK);
 	}
 
-	m_bVPUseSuperRes = (m_D3D11VP.SetSuperRes(m_bVPScaling ? m_iVPSuperRes : 0) == S_OK);
 	m_bVPUseRTXVideoHDR = (m_D3D11VP.SetRTXVideoHDR(RTXVideoHDRValid()) == S_OK);
+	auto superRes = (m_bVPScaling && !(m_bHdrPassthroughSupport && m_bHdrPassthrough && SourceIsHDR())) ? m_iVPSuperRes : SUPERRES_Disable;
+	m_bVPUseSuperRes = (m_D3D11VP.SetSuperRes(superRes) == S_OK);
 
 	hr = m_TexSrcVideo.Create(m_pDevice, dxgiFormat, width, height, Tex2D_DynamicShaderWriteNoSRV);
 	if (FAILED(hr)) {
@@ -3523,7 +3524,8 @@ void CDX11VideoProcessor::Configure(const Settings_t& config)
 	}
 
 	if (changeSuperRes) {
-		m_bVPUseSuperRes = (m_D3D11VP.SetSuperRes(m_bVPScaling ? m_iVPSuperRes : 0) == S_OK);
+		auto superRes = (m_bVPScaling && !(m_bHdrPassthroughSupport && m_bHdrPassthrough && SourceIsHDR())) ? m_iVPSuperRes : SUPERRES_Disable;
+		m_bVPUseSuperRes = (m_D3D11VP.SetSuperRes(superRes) == S_OK);
 	}
 
 	UpdateStatsStatic();

--- a/Source/DX11VideoProcessor.cpp
+++ b/Source/DX11VideoProcessor.cpp
@@ -1800,9 +1800,8 @@ HRESULT CDX11VideoProcessor::InitializeD3D11VP(const FmtConvParams_t& params, co
 		m_bRTXVideoHDR_supported = (m_D3D11VP.SetRTXVideoHDR(true) == S_OK);
 	}
 
+	m_bVPUseSuperRes = (m_D3D11VP.SetSuperRes(m_bVPScaling ? m_iVPSuperRes : 0) == S_OK);
 	m_bVPUseRTXVideoHDR = (m_D3D11VP.SetRTXVideoHDR(RTXVideoHDRValid()) == S_OK);
-	auto superRes = (m_bVPScaling && !(m_bHdrPassthroughSupport && m_bHdrPassthrough && SourceIsHDR())) ? m_iVPSuperRes : SUPERRES_Disable;
-	m_bVPUseSuperRes = (m_D3D11VP.SetSuperRes(superRes) == S_OK);
 
 	hr = m_TexSrcVideo.Create(m_pDevice, dxgiFormat, width, height, Tex2D_DynamicShaderWriteNoSRV);
 	if (FAILED(hr)) {
@@ -3524,8 +3523,7 @@ void CDX11VideoProcessor::Configure(const Settings_t& config)
 	}
 
 	if (changeSuperRes) {
-		auto superRes = (m_bVPScaling && !(m_bHdrPassthroughSupport && m_bHdrPassthrough && SourceIsHDR())) ? m_iVPSuperRes : SUPERRES_Disable;
-		m_bVPUseSuperRes = (m_D3D11VP.SetSuperRes(superRes) == S_OK);
+		m_bVPUseSuperRes = (m_D3D11VP.SetSuperRes(m_bVPScaling ? m_iVPSuperRes : 0) == S_OK);
 	}
 
 	UpdateStatsStatic();

--- a/Source/DX11VideoProcessor.h
+++ b/Source/DX11VideoProcessor.h
@@ -151,6 +151,10 @@ private:
 
 	int m_iVPSuperRes = 0;
 	bool m_bVPUseSuperRes = false; // but it is not exactly
+	bool m_bVPRTXVideoHDR = false;
+	bool m_bVPUseRTXVideoHDR = false;
+	bool m_bRTXVideoHDR_supported = false;
+	bool m_bGPUEnhancementsChecked = false;
 
 	bool m_bHdrPassthroughSupport = false;
 	bool m_bHdrDisplaySwitching   = false; // switching HDR display in progress
@@ -213,6 +217,7 @@ private:
 	}
 
 	bool HandleHDRToggle();
+	bool RTXVideoHDRValid();
 
 public:
 	HRESULT SetDevice(ID3D11Device *pDevice, ID3D11DeviceContext *pContext, const bool bDecoderDevice);

--- a/Source/IVideoRenderer.h
+++ b/Source/IVideoRenderer.h
@@ -94,6 +94,7 @@ struct Settings_t {
 	bool bDeintDouble;
 	bool bVPScaling;
 	int iVPSuperRes;
+	bool bVPRTXVideoHDR;
 	int  iChromaScaling;
 	int  iUpscaling;
 	int  iDownscaling;
@@ -130,6 +131,7 @@ struct Settings_t {
 		bDeintDouble                    = true;
 		bVPScaling                      = true;
 		iVPSuperRes                     = SUPERRES_Disable;
+		bVPRTXVideoHDR                  = false;
 		iChromaScaling                  = CHROMA_Bilinear;
 		iUpscaling                      = UPSCALE_CatmullRom;
 		iDownscaling                    = DOWNSCALE_Hamming;

--- a/Source/MpcVideoRenderer.rc
+++ b/Source/MpcVideoRenderer.rc
@@ -83,7 +83,7 @@ BEGIN
     CONTROL         "Use dithering",IDC_CHECK10,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,10,199,59,10
     CONTROL         "Use Blend deinterlacing for YUV 4:2:0",IDC_CHECK17,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,10,212,139,10
-    GROUPBOX        "HDR",IDC_STATIC,171,35,176,96
+    GROUPBOX        "HDR",IDC_STATIC,171,35,176,110
     CONTROL         "Prefer Dolby Vision over PQ and HLG",IDC_CHECK18,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,178,47,135,10
     CONTROL         "Passthrough to display",IDC_CHECK12,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,178,60,89,10
     LTEXT           " if not possible",IDC_STATIC4,178,73,48,8
@@ -92,14 +92,15 @@ BEGIN
     COMBOBOX        IDC_COMBO7,232,98,110,30,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
     LTEXT           "Subtitle and OSD brightness:",IDC_STATIC6,178,115,95,8
     CONTROL         "",IDC_SLIDER1,"msctls_trackbar32",TBS_BOTH | TBS_NOTICKS | WS_TABSTOP,277,114,65,12
-    LTEXT           "Swap effect:",IDC_STATIC3,174,137,43,8
-    COMBOBOX        IDC_COMBO4,249,134,76,30,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
-    CONTROL         "Use exclusive fullscreen",IDC_CHECK11,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,174,150,93,10
-    CONTROL         "Wait for VBlank before Present",IDC_CHECK15,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,174,163,117,10
-    CONTROL         "Reinitialize D3D device when changing display",IDC_CHECK16,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,174,176,168,10
+    LTEXT           "Swap effect:",IDC_STATIC3,178,151,43,8
+    COMBOBOX        IDC_COMBO4,266,148,76,30,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    CONTROL         "Use exclusive fullscreen",IDC_CHECK11,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,178,164,93,10
+    CONTROL         "Wait for VBlank before Present",IDC_CHECK15,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,178,177,117,10
+    CONTROL         "Reinitialize device when changing display",IDC_CHECK16,
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,178,190,151,10
     PUSHBUTTON      "Default",IDC_BUTTON1,305,211,37,14
     EDITTEXT        IDC_EDIT2,76,229,266,12,ES_READONLY | NOT WS_BORDER,WS_EX_RIGHT
+    CONTROL         "RTX Video HDR",IDC_CHECK19,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,178,129,66,10
 END
 
 IDD_INFOPROPPAGE DIALOGEX 0, 0, 318, 153

--- a/Source/PropPage.cpp
+++ b/Source/PropPage.cpp
@@ -95,6 +95,7 @@ void CVRMainPPage::SetControls()
 	CheckDlgButton(IDC_CHECK3, m_SetsPP.bDeintDouble          ? BST_CHECKED : BST_UNCHECKED);
 	CheckDlgButton(IDC_CHECK5, m_SetsPP.bVPScaling            ? BST_CHECKED : BST_UNCHECKED);
 	SendDlgItemMessageW(IDC_COMBO8, CB_SETCURSEL, m_SetsPP.iVPSuperRes, 0);
+	CheckDlgButton(IDC_CHECK19, m_SetsPP.bVPRTXVideoHDR       ? BST_CHECKED : BST_UNCHECKED);
 
 	CheckDlgButton(IDC_CHECK18, m_SetsPP.bHdrPreferDoVi       ? BST_CHECKED : BST_UNCHECKED);
 	CheckDlgButton(IDC_CHECK12, m_SetsPP.bHdrPassthrough      ? BST_CHECKED : BST_UNCHECKED);
@@ -144,6 +145,7 @@ void CVRMainPPage::EnableControls()
 		GetDlgItem(IDC_SLIDER1).EnableWindow(bEnable);
 		GetDlgItem(IDC_STATIC7).EnableWindow(bEnable && m_SetsPP.bVPScaling);
 		GetDlgItem(IDC_COMBO8).EnableWindow(bEnable && m_SetsPP.bVPScaling);
+		GetDlgItem(IDC_CHECK19).EnableWindow(bEnable);
 	}
 }
 
@@ -190,6 +192,7 @@ HRESULT CVRMainPPage::OnActivate()
 		GetDlgItem(IDC_SLIDER1).EnableWindow(FALSE);
 		GetDlgItem(IDC_STATIC7).EnableWindow(FALSE);
 		GetDlgItem(IDC_COMBO8).EnableWindow(FALSE);
+		GetDlgItem(IDC_CHECK19).EnableWindow(FALSE);
 	}
 
 	EnableControls();
@@ -276,6 +279,7 @@ INT_PTR CVRMainPPage::OnReceiveMessage(HWND hwnd, UINT uMsg, WPARAM wParam, LPAR
 				SetDirty();
 				GetDlgItem(IDC_STATIC7).EnableWindow(m_SetsPP.bVPScaling && m_SetsPP.bUseD3D11 && IsWindows10OrGreater());
 				GetDlgItem(IDC_COMBO8).EnableWindow(m_SetsPP.bVPScaling && m_SetsPP.bUseD3D11 && IsWindows10OrGreater());
+				GetDlgItem(IDC_CHECK19).EnableWindow(m_SetsPP.bUseD3D11 && IsWindows10OrGreater());
 				return (LRESULT)1;
 			}
 			if (nID == IDC_CHECK6) {
@@ -344,7 +348,11 @@ INT_PTR CVRMainPPage::OnReceiveMessage(HWND hwnd, UINT uMsg, WPARAM wParam, LPAR
 				SetDirty();
 				return (LRESULT)1;
 			}
-
+			if (nID == IDC_CHECK19) {
+				m_SetsPP.bVPRTXVideoHDR = IsDlgButtonChecked(IDC_CHECK19) == BST_CHECKED;
+				SetDirty();
+				return (LRESULT)1;
+			}
 			if (nID == IDC_BUTTON1) {
 				m_SetsPP.SetDefault();
 				SetControls();

--- a/Source/VideoRenderer.cpp
+++ b/Source/VideoRenderer.cpp
@@ -42,6 +42,7 @@
 #define OPT_DoubleFrateDeint               L"DoubleFramerateDeinterlace"
 #define OPT_VPScaling                      L"VPScaling"
 #define OPT_VPSuperResolution              L"VPSuperResolution"
+#define OPT_VPRTXVideoHDR                  L"VPRTXVideoHDR"
 #define OPT_ChromaUpsampling               L"ChromaUpsampling"
 #define OPT_Upscaling                      L"Upscaling"
 #define OPT_Downscaling                    L"Downscaling"
@@ -193,6 +194,9 @@ CMpcVideoRenderer::CMpcVideoRenderer(LPUNKNOWN pUnk, HRESULT* phr)
 		}
 		if (ERROR_SUCCESS == key.QueryDWORDValue(OPT_VPSuperResolution, dw)) {
 			m_Sets.iVPSuperRes = discard<int>(dw, SUPERRES_Disable, 0, SUPERRES_COUNT-1);;
+		}
+		if (ERROR_SUCCESS == key.QueryDWORDValue(OPT_VPRTXVideoHDR, dw)) {
+			m_Sets.bVPRTXVideoHDR = !!dw;
 		}
 		if (ERROR_SUCCESS == key.QueryDWORDValue(OPT_ChromaUpsampling, dw)) {
 			m_Sets.iChromaScaling = discard<int>(dw, CHROMA_Bilinear, 0, CHROMA_COUNT-1);
@@ -1189,6 +1193,7 @@ STDMETHODIMP CMpcVideoRenderer::SaveSettings()
 		key.SetDWORDValue(OPT_DoubleFrateDeint,    m_Sets.bDeintDouble);
 		key.SetDWORDValue(OPT_VPScaling,           m_Sets.bVPScaling);
 		key.SetDWORDValue(OPT_VPSuperResolution,   m_Sets.iVPSuperRes);
+		key.SetDWORDValue(OPT_VPRTXVideoHDR,       m_Sets.bVPRTXVideoHDR);
 		key.SetDWORDValue(OPT_ChromaUpsampling,    m_Sets.iChromaScaling);
 		key.SetDWORDValue(OPT_Upscaling,           m_Sets.iUpscaling);
 		key.SetDWORDValue(OPT_Downscaling,         m_Sets.iDownscaling);

--- a/Source/resource.h
+++ b/Source/resource.h
@@ -113,6 +113,7 @@
 #define IDC_CHECK16                     1036
 #define IDC_CHECK17                     1037
 #define IDC_CHECK18                     1038
+#define IDC_CHECK19                     1039
 #define IDC_COMBO1                      1041
 #define IDC_COMBO2                      1042
 #define IDC_COMBO3                      1043


### PR DESCRIPTION
Just the RTX Video HDR support in this one, as requested by: https://github.com/Aleksoid1978/VideoRenderer/pull/127#issuecomment-1933284863

NOTE:
this only touches anything that's needed for RTX Video HDR, therefore it does not include the fixes from the previous PR such as:
Better Super Resolution validity checks and better support for HDR screens; using Super Resolution above 1080p; allowing the use of custom scalers when Super Resolution is not active; allowing Super Resolution for HDR videos when viewed in SDR (https://github.com/Aleksoid1978/VideoRenderer/commit/6e7d3d9f6cf7000da6151d0c854a4fdde9180671)
Support different aspect ratios for Super Resolution (https://github.com/Aleksoid1978/VideoRenderer/commit/088aca8d18c7925bb84d1e1e4db69732783551a1)
Option to disable Super Resolution if window is the same size as the video, issue here https://github.com/Aleksoid1978/VideoRenderer/issues/126 (https://github.com/Aleksoid1978/VideoRenderer/commit/dd46fafd65c82786780e37226cd696c07ee99d3b)
Disabling passthrough does not reset the window to SDR (https://github.com/Aleksoid1978/VideoRenderer/commit/8bb15a64bd459ffb7b9ad292384ceea4813ab269) (https://github.com/Aleksoid1978/VideoRenderer/commit/9edf103113b6ad4e24db5c1f690dd11749a9d4c0)
Toggling between fullscreen and windowed in certain scenarios makes the renderer think we are on a different monitor (https://github.com/Aleksoid1978/VideoRenderer/commit/7dfd9989e31e801f275f6b2a7bc681f6adbb09ac)
