### PR TITLE
implement simplified frame syncing (fix issue #45)

### DIFF
--- a/Source/DX11VideoProcessor.h
+++ b/Source/DX11VideoProcessor.h
@@ -216,6 +216,7 @@ private:
 	}
 
 	bool HandleHDRToggle();
+	void SleepToSync(CRefTime& rtClock, const REFERENCE_TIME& rtStart);
 
 public:
 	HRESULT SetDevice(ID3D11Device *pDevice, ID3D11DeviceContext *pContext, const bool bDecoderDevice);


### PR DESCRIPTION
fixing issue #45.

The issue with MPC VR currently is that calling Render() twice in a row, as would be done for interlaced content, is that on displays where the refresh rate does not match the content frame rate, the frame delivery would not be consistent as the second field (Render(2)) would scan out on the next immediate refresh cycle, instead of waiting for it's proper turn.

Let's take this example: 240Hz display, 30fps content.
If this was not interlaced, you would expect the renderer to present a new video frame every 240/30 = 8 refreshes.
And if it was interlaced, you would expect it to present a new frame every 240/(30 * 2) = 4 refreshes, if frame doubling is enabled (which is by default).
We would expect frames to render like this:
Field 1 - blank - blank - blank - Field 2 - blank - blank - blank
But that is not what happens as is. Instead, this is what we currently have:
Field 1 - Field 2 - blank - blank - blank - blank - blank - blank
give or take some variability, sometimes there is a single blank between Field 1 and Field 2.

This issue happens on any screen that has a refresh rate higher than double the interlaced frame rate when the 'double interlaced frame rate' option is on (25i on 60Hz too), though it gets more noticeable as the refresh rate increases. 
How do you test if you have this issue on your own screen with your particular content? Play a video and open the debug panel, then check the frametime graph - if you see a sawtooth pattern, then you're affected by this bug.

The simplest way I've found to fix this issue is by sleeping the renderer until we want the frame to be drawn.
I've tried to keep the code short and easy to understand. The algorithm I've got in my own branch is much more fleshed out and adaptive, plus it removes nearly all frametime variance and variance introduced by the actual sleep() call itself, but the code is rather cryptic so this one that goes 90% of the way should suffice.

I haven't really noticed any downsides to having this always-on, since it does not run unless we finish processing the frame long before it should be rendered.