### PR TITLE
Fix display switching

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "ms-vscode.cpptools-extension-pack",
+        "spmeesseman.vscode-taskexplorer"
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,48 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "shell",
+            "label": "Build AX",
+            "command": "build_mpcvr.cmd",
+            "options": {
+                "cwd": "${workspaceFolder}",
+                "shell": {
+                    "executable": "cmd.exe",
+                    "args": [ "/d", "/c" ]
+                }
+            },
+            "runOptions": {
+                "instanceLimit": 1,
+            },
+            "osx": {
+                "hide": true
+            },
+            "linux": {
+                "hide": true
+            }
+        },
+        {
+            "type": "shell",
+            "label": "Build Debug AX",
+            "command": "build_mpcvr.cmd",
+            "args": [ "Debug" ],
+            "options": {
+                "cwd": "${workspaceFolder}",
+                "shell": {
+                    "executable": "cmd.exe",
+                    "args": [ "/d", "/c" ]
+                }
+            },
+            "runOptions": {
+                "instanceLimit": 1,
+            },
+            "osx": {
+                "hide": true
+            },
+            "linux": {
+                "hide": true
+            }
+        }
+    ]
+}

--- a/Source/DX11VideoProcessor.cpp
+++ b/Source/DX11VideoProcessor.cpp
@@ -1353,10 +1353,18 @@ HRESULT CDX11VideoProcessor::InitSwapChain()
 	if (bFullscreenChange) {
 		HandleHDRToggle();
 		UpdateBitmapShader();
+		bool bIsSourcePQorHLG = SourceIsPQorHLG();
 
-		if (m_bHdrPassthrough
-				&& ((m_iHdrToggleDisplay == HDRTD_On_Fullscreen && m_bIsFullscreen) || m_iHdrToggleDisplay == HDRTD_OnOff_Fullscreen)
-				&& SourceIsPQorHLG()) {
+		DLog(L"CDX11VideoProcessor::InitSwapChain() - Is fullscreen: {}", m_bIsFullscreen);
+		DLog(L"CDX11VideoProcessor::InitSwapChain() - Is source PQ or HLG: {}", bIsSourcePQorHLG);
+		DLog(L"CDX11VideoProcessor::InitSwapChain() - HDR pass-through: {}", m_bHdrPassthrough);
+		DLog(L"CDX11VideoProcessor::InitSwapChain() - HDR toggle display: {}", m_iHdrToggleDisplay);
+
+		// Reinit to do the following:
+		// 1. Fullscreen toggle (based on user preference)
+		// 2. HDR toggle (based on user preference)
+		// 3. HDR settings check (if HDR toggle is disabled: check fullscreen display mode, which may differ from current display)
+		if (m_bHdrPassthrough && bIsSourcePQorHLG) {
 			m_bHdrAllowSwitchDisplay = false;
 			InitMediaType(&m_pFilter->m_inputMT);
 			m_bHdrAllowSwitchDisplay = true;

--- a/Source/VideoRenderer.cpp
+++ b/Source/VideoRenderer.cpp
@@ -1091,7 +1091,13 @@ STDMETHODIMP CMpcVideoRenderer::SetWindowPosition(long Left, long Top, long Widt
 
 	CAutoLock cRendererLock(&m_RendererLock);
 
-	if (!m_bIsD3DFullscreen && (m_Sets.bExclusiveFS || m_bIsFullscreen)) {
+	DLog(L"CMpcVideoRenderer::SetWindowPosition() - Is D3D fullscreen: {}", m_bIsD3DFullscreen);
+	DLog(L"CMpcVideoRenderer::SetWindowPosition() - Is exclusive fullscreen: {}", m_Sets.bExclusiveFS);
+	DLog(L"CMpcVideoRenderer::SetWindowPosition() - Is fullscreen: {}", m_bIsFullscreen);
+
+	// Reinit whether in exclusive and non-exclusive fullscreen mode to do the following:
+	// HDR settings check (if HDR toggle is disabled: check fullscreen display mode, which may differ from current display)
+	if (!m_bIsD3DFullscreen) {
 		const HMONITOR hMon = MonitorFromWindow(m_hWnd, MONITOR_DEFAULTTONEAREST);
 		MONITORINFO mi = { mi.cbSize = sizeof(mi) };
 		::GetMonitorInfoW(hMon, &mi);


### PR DESCRIPTION
This pull request fixes the issue https://github.com/Aleksoid1978/VideoRenderer/issues/176.
Previously, both "HDR toggle" and "Exclusive fullscreen" had to be enabled in order for MPCVR to properly detect a display change during a fullscreen transition. This caused issues if the initial display is in SDR mode while the fullscreen display is in HDR mode and vice versa.
Additionally I added some basic configuration for Visual Studio Code to to enable the user to perform build tasks with one click.

Please correct me if my changes may have unwanted side effects that I might not be able to foresee, as I don't have the bigger picture.