### PR TITLE
shaders/hdr_tonemap: clamp color to (0, 1)

### DIFF
--- a/Shaders/d3d11/ps_hdr10_tonemap.hlsl
+++ b/Shaders/d3d11/ps_hdr10_tonemap.hlsl
@@ -273,6 +273,7 @@ float4 main(PS_INPUT input) : SV_Target
 {
 	// Sample texture and convert from PQ to linear
 	float4 color = tex.Sample(samp, input.Tex);
+    color = saturate(color);
 	color = ST2084ToLinear(color, 10000.0f); // Convert PQ to Linear space
 
 	if (L2Enabled)


### PR DESCRIPTION
Sharp scalers like lanczos create negative lobes which can cause weird artifacts when tonemapping. Using 16 bit float internal textures carries these negative values over to the tonemap shader which causes NaN values resulting in weird black pixelisation.