### PR TITLE
Dolby Vision: don't map dovi metadata for full enhancement layer

### DIFF
--- a/Source/VideoProcessor.cpp
+++ b/Source/VideoProcessor.cpp
@@ -278,6 +278,10 @@ bool CVideoProcessor::CheckDoviMetadata(const MediaSideDataDOVIMetadata* pDOVIMe
 		return false;
 	}
 
+	// Ignore Profile 7 Full Enhancement Layer as its currently not supported
+	if (SourceIsDoviFel(pDOVIMetadata))
+		return false;
+
 	for (const auto& curve : pDOVIMetadata->Mapping.curves) {
 		if (curve.num_pivots < 2 || curve.num_pivots > 9) {
 			return false;

--- a/Source/VideoProcessor.h
+++ b/Source/VideoProcessor.h
@@ -244,6 +244,24 @@ protected:
 		return SourceIsPQorHLG() || m_Dovi.bValid;
 	}
 
+	// Check if source is Dolby Vision Full Enhancement Layer
+	inline bool SourceIsDoviFel(const MediaSideDataDOVIMetadata* pDOVIMetadata) {
+		if (pDOVIMetadata->Header.disable_residual_flag)
+			return false;
+
+		if (pDOVIMetadata->Mapping.nlq_method_idc == 0) {
+			for (uint8_t i = 0; i < 3; i++) {
+				if (pDOVIMetadata->Mapping.nlq[i].nlq_offset != 0 ||
+					pDOVIMetadata->Mapping.nlq[i].vdr_in_max != (1ULL << pDOVIMetadata->Header.coef_log2_denom) ||
+					pDOVIMetadata->Mapping.nlq[i].linear_deadzone_slope != 0 ||
+					pDOVIMetadata->Mapping.nlq[i].linear_deadzone_threshold != 0)
+					return true;
+			}
+		}
+
+		return false;
+	}
+
 	void UpdateStatsInputFmt();
 
 	CRefTime m_streamTime;


### PR DESCRIPTION
Dolby Vision Full Enhancement Layer requires the extra enhancement layer for mapping. Applying the Poly and MMR curves to the base layer without properly merging the enhancement layer may lead to undesirable results.

Sample 1: https://drive.google.com/file/d/1VPpBxuAZGJdsmECXY5Wowmvkxo8jHoS9/view?usp=sharing

There is a weird flash around 00:18 

Sample 2: https://drive.google.com/file/d/1HirhGBQKzDS-KVflrg5I8Pfly-vmJjk-/view?usp=sharing

The colors flicker all over the place in sample 2

We shouldn't map Dovi metadata for profile 7 FEL. Atleast until we can get proper support for FEL merging on Windows.