### PR TITLE
Fix HLG OOTF: missing /12 normalization in inverse OETF causes undefined peak luminance

### DIFF
--- a/Shaders/convert/hlg.hlsl
+++ b/Shaders/convert/hlg.hlsl
@@ -14,7 +14,7 @@ inline float3 HLGtoLinear(float3 rgb)
 {
     rgb = inverse_HLG(rgb);
     float3 ootf_2020 = float3(0.2627, 0.6780, 0.0593);
-    float Ys = dot(ootf_2020, rgb);
-    rgb *= 1000.0f * pow(Ys, 0.2f);
+    float ootf_ys = dot(ootf_2020, rgb);
+    rgb *= 1000.0f * pow(ootf_ys, 0.2f);
     return rgb; 
 }

--- a/Shaders/convert/hlg.hlsl
+++ b/Shaders/convert/hlg.hlsl
@@ -7,14 +7,14 @@ inline float3 inverse_HLG(float3 rgb)
     rgb = (rgb <= 0.5)
         ? rgb * rgb * B67_inv_r2
         : exp((rgb - B67_c) / B67_a) + B67_b;
-    return rgb;
+    return rgb / 12.0f;
 }
 
 inline float3 HLGtoLinear(float3 rgb)
 {
     rgb = inverse_HLG(rgb);
     float3 ootf_2020 = float3(0.2627, 0.6780, 0.0593);
-    float ootf_ys = 2000.0f * dot(ootf_2020, rgb);
-    rgb *= pow(ootf_ys, 0.2f);
-    return rgb;
+    float Ys = dot(ootf_2020, rgb);
+    rgb *= 1000.0f * pow(Ys, 0.2f);
+    return rgb; 
 }

--- a/Shaders/d3d11/ps_convert_hlg_to_pq.hlsl
+++ b/Shaders/d3d11/ps_convert_hlg_to_pq.hlsl
@@ -16,7 +16,7 @@ float4 main(PS_INPUT input) : SV_Target
 
     color = saturate(color); // use saturate(), because pow() can not take negative values
     color.rgb = HLGtoLinear(color.rgb);
-    color = LinearToST2084(color, 1000.0);
+    color = LinearToST2084(color, 10000.0);
 
     return color;
 }

--- a/Shaders/d3d11/ps_fixconvert_hlg_to_sdr.hlsl
+++ b/Shaders/d3d11/ps_fixconvert_hlg_to_sdr.hlsl
@@ -31,7 +31,7 @@ float4 main(PS_INPUT input) : SV_Target
     // HLG to PQ
     color = saturate(color);
     color.rgb = HLGtoLinear(color.rgb);
-    color = LinearToST2084(color, 1000.0);
+    color = LinearToST2084(color, 10000.0);
 
     // PQ to Linear
     color = saturate(color);

--- a/Shaders/d3d9/fixconvert_hlg_to_sdr.hlsl
+++ b/Shaders/d3d9/fixconvert_hlg_to_sdr.hlsl
@@ -21,7 +21,7 @@ float4 main(float2 tex : TEXCOORD0) : COLOR
     // HLG to PQ
     color = saturate(color);
     color.rgb = HLGtoLinear(color.rgb);
-    color = LinearToST2084(color, 1000.0);
+    color = LinearToST2084(color, 10000.0);
 
     // PQ to Linear
     color = saturate(color);


### PR DESCRIPTION
Note: As I am not confident in my English, the following text was written by Claude.

The second branch of inverse_HLG() (for E' > 0.5) implements the ARIB STD-B67 / ITU-R BT.2100 inverse OETF, whose full form is:

E = (exp((E' - c) / a) + b) / 12

The trailing / 12 is missing from the current implementation. This factor is not cosmetic — it is the normalization that maps the inverse OETF output back into the 0–1 relative scene-light range defined by the standard. Without it, inverse_HLG() returns values scaled by roughly 12x (e.g. 1.0 at full signal instead of the correct 1.0/12).

This distortion isn't obvious in isolation, but it surfaces in HLGtoLinear(), where the OOTF is applied. The standard HLG OOTF is:

FD = alpha × Ys^(gamma-1) × E   (gamma = 1.2, so exponent = 0.2)

Here alpha is an explicit parameter representing peak luminance in nits. In the current code, this is instead baked into a hardcoded 2000.0f multiplier:

float ootf_ys = 2000.0f * dot(ootf_2020, rgb);

Because rgb at this point is still the un-normalized (×12) output from `inverse_HLG()`, the 2000.0 constant is not actually representing alpha alone — it's compensating for the missing normalization and trying to encode a peak luminance at the same time, mixed together through a power-0.2 term. As a result:

- The actual effective peak luminance produced by this code does not correspond to any of the standard BT.2100 reference levels (100 / 400 / 1000 / 10000 nits).
- There is no way to reason about, or intentionally change, the target peak brightness from the code as written — 2000.0 is not derivable from any documented parameter.
- The implementation cannot be validated against the standard formula, since the normalization step and the OOTF step are conflated into a single magic number.

**Fix**
1. `inverse_HLG()`: add the missing `/ 12.0f` normalization, so the function returns values correctly normalized to the 0–1 relative scene-light range, per spec.
2. `HLGtoLinear():` rewrite the OOTF to match the standard formula FD = alpha × Ys^(gamma-1) × E directly, with alpha = 1000.0f (target peak luminance in nits) as an explicit, separate multiplier. After this change, `HLGtoLinear()`'s return value has an unambiguous meaning: it's the actual nits value, not a normalized/relative value.
3. Call sites (`ps_fixconvert_hlg_to_sdr.hlsl`, and any equivalent d3d9 shader if present): update the divider argument passed to LinearToST2084 from 1000.0 to 10000.0, to match the change in `HLGtoLinear()`'s output unit (previously a relative/normalized value, now actual nits). `LinearToST2084` expects input normalized against the PQ reference of 1.0 = 10000 nits, so this divider must match the new output scale.

**Verification**

With input signal 1.0 (HLG 100%):

inverse_HLG(1.0) = 12.0 / 12 = 1.0 (correctly normalized)
Ys = 1.0
OOTF: 1000.0 × pow(1.0, 0.2) = 1000.0 nits
LinearToST2084(1000.0, 10000.0): 1000.0 / 10000.0 = 0.1, correctly fed into the PQ inverse EOTF

HLG 100% is now correctly encoded as exactly 1000 nits in PQ, as intended.